### PR TITLE
Avoid keywords being interpreted as poetic number literals.

### DIFF
--- a/rockstarpy/__init__.py
+++ b/rockstarpy/__init__.py
@@ -88,9 +88,8 @@ def create_if(line):
 
 def find_poetic_number_literal(line):
     global regex_variables
-    poetic_type_literals_keywords = ['true', 'false', 'nothing', 'nobody', 'nowhere']
     match = re.match(r'\b({})(?: is|\'s| was| were) (.+)'.format(regex_variables), line)
-    if match and match.group(2).split()[0] not in poetic_type_literals_keywords:
+    if match and match.group(2).split()[0] not in [key.strip() for key in simple_subs.keys()]:
         line = '{} = '.format(match.group(1))
         for word_number in match.group(2).split():
             period = '.' if word_number.endswith('.') else ''


### PR DESCRIPTION
A previous commit (8698c4cbbd62cf31...) made a change that did not work for the keyword "empty", which was causing the fizz.rock translation to set "My world is empty" to "my_world = 5" when it should be "my_world = False". This commit makes sure none of the simple_subs are interpreted as poetic number literals.