### PR TITLE
Add spaces to the beginning of comments.

### DIFF
--- a/rockstarpy/transpile.py
+++ b/rockstarpy/transpile.py
@@ -60,7 +60,7 @@ class Transpiler(object):
     def get_comments(self, line):
         if '(' in line:
             line, comment = line.split('(')
-            comment = ' #' + comment.strip(')\n ')
+            comment = ' # ' + comment.strip(')\n ')
         else:
             comment = ''
         return line, comment


### PR DESCRIPTION
Currently, when a Rockstar comment is converted to Python, we get something among the lines of "#COMMENT".

A small change would be to add a space between the pound sign and the actual comment, allowing the code to follow [PEP 8](https://www.python.org/dev/peps/pep-0008/#inline-comments) standards as well as making the comments more readable.